### PR TITLE
PHP 8.1, 8.2 support

### DIFF
--- a/src/HunSpellPhpWrapper/DictionaryEditor.php
+++ b/src/HunSpellPhpWrapper/DictionaryEditor.php
@@ -53,7 +53,7 @@ class DictionaryEditor
      * @return bool
      * @author Synida Pry
      */
-    public function create($path)
+    public function create(string $path)
     {
         $pathParts = explode('.', $path);
         $extension = end($pathParts);
@@ -97,7 +97,7 @@ class DictionaryEditor
      * @return bool
      * @author Synida Pry
      */
-    public function delete($path)
+    public function delete(string $path)
     {
         $pathParts = explode('.', $path);
         $extension = end($pathParts);
@@ -131,7 +131,7 @@ class DictionaryEditor
      * @return bool
      * @author Synida Pry
      */
-    public function addWord($path, $word)
+    public function addWord(string $path, string $word)
     {
         // Check empty or invalid word
         if ($this->isInvalidWord($word)) {
@@ -180,7 +180,7 @@ class DictionaryEditor
      * @return bool
      * @author Synida Pry
      */
-    protected function isInvalidWord($word)
+    protected function isInvalidWord(string $word)
     {
         if (empty(trim($word))) {
             return true;
@@ -197,7 +197,7 @@ class DictionaryEditor
      * @return bool
      * @author Synida Pry
      */
-    public function deleteWord($path, $word)
+    public function deleteWord(string $path, string $word)
     {
         $ext = pathinfo($path, PATHINFO_EXTENSION);
 
@@ -245,7 +245,7 @@ class DictionaryEditor
      * @return bool
      * @author Synida Pry
      */
-    public function editWord($path, $word, $modifiedWord)
+    public function editWord(string $path, string $word, string $modifiedWord)
     {
         // Check empty or invalid word
         if ($this->isInvalidWord($modifiedWord)) {
@@ -303,11 +303,11 @@ class DictionaryEditor
      * @return array
      * @author Synida Pry
      */
-    public function listWords($path)
+    public function listWords(string $path)
     {
         $dictionaryContent = file_get_contents($path);
 
-        $dictionaryContent = preg_replace('/(\r\n)|\r|\n/', PHP_EOL, $dictionaryContent);
+        $dictionaryContent = preg_replace('/(\r\n)|\r|\n/', PHP_EOL, (string)$dictionaryContent);
         $result = explode(PHP_EOL, $dictionaryContent);
 
         if (isset($result[0]) && is_numeric($result[0])) {
@@ -335,11 +335,11 @@ class DictionaryEditor
      * @return array
      * @author Synida Pry
      */
-    protected function getDictionaryWords($path)
+    protected function getDictionaryWords(string $path)
     {
         $dictionaryContent = file_get_contents($path);
 
-        $dictionaryContent = preg_replace('/(\r\n)|\r|\n/', PHP_EOL, $dictionaryContent);
+        $dictionaryContent = preg_replace('/(\r\n)|\r|\n/', PHP_EOL, (string)$dictionaryContent);
         $words = explode(PHP_EOL, $dictionaryContent);
 
         if (isset($words[0]) && is_numeric($words[0])) {

--- a/src/HunSpellPhpWrapper/HunSpell.php
+++ b/src/HunSpellPhpWrapper/HunSpell.php
@@ -160,11 +160,11 @@ class HunSpell
      * @author Synida Pry
      */
     public function __construct(
-        $encoding = 'en_GB.utf8',
-        $dictionary = 'en_GB',
-        $responseType = 'json',
-        $threads = 1,
-        $wordThreadRatio = 1
+        string $encoding = 'en_GB.utf8',
+        string $dictionary = 'en_GB',
+        string $responseType = 'json',
+        int $threads = 1,
+        int $wordThreadRatio = 1
     ) {
         $this->inputValidator = new InputValidator();
 
@@ -208,7 +208,7 @@ class HunSpell
      * @throws InvalidResponseTypeException
      * @author Synida Pry
      */
-    public function setResponseType($responseType)
+    public function setResponseType(string $responseType)
     {
         // Validates the response type
         $this->inputValidator->validateResponseType($responseType);
@@ -234,7 +234,7 @@ class HunSpell
      * @return void
      * @author Synida Pry
      */
-    public function setDictionary($dictionary)
+    public function setDictionary(string $dictionary)
     {
         $this->dictionary = $dictionary;
     }
@@ -257,7 +257,7 @@ class HunSpell
      * @return void
      * @author Synida Pry
      */
-    public function setEncoding($encoding)
+    public function setEncoding(string $encoding)
     {
         $this->encoding = $encoding;
     }
@@ -270,7 +270,7 @@ class HunSpell
      * @throws Exception
      * @author Synida Pry
      */
-    public function suggest($text)
+    public function suggest(string $text)
     {
         $result = [];
 
@@ -286,7 +286,7 @@ class HunSpell
                 // Executes the find command on a text.
                 : $this->findCommand($text);
 
-        preg_replace('/(\r\n)|\r|\n/', "\n", $spellCheckResults);
+        preg_replace('/(\r\n)|\r|\n/', "\n", (string)$spellCheckResults);
         $resultLines = explode("\n", trim($spellCheckResults));
         unset($resultLines[0]);
 
@@ -342,7 +342,7 @@ class HunSpell
      * @throws Exception
      * @author Synida Pry
      */
-    protected function findWithThreading($text, $wordCount)
+    protected function findWithThreading(string $text, int $wordCount)
     {
         // Returns with the configured max thread count.
         $optimalThread = $this->getOptimalThreads($wordCount);
@@ -355,9 +355,7 @@ class HunSpell
         $result = '';
         $threads = [];
         try {
-            $threadCount = (int)ceil(
-                $wordCount / $chunkSize > $optimalThread ? $optimalThread : $wordCount / $chunkSize
-            );
+            $threadCount = (int)ceil(min($wordCount / $chunkSize, $optimalThread));
             for ($i = 0; $i < $threadCount; $i++) {
                 $chunk = '';
                 $initPosition = $i * $chunkSize;
@@ -394,7 +392,7 @@ class HunSpell
      * @return int
      * @author Synida Pry
      */
-    public function getOptimalThreads($wordCount)
+    public function getOptimalThreads(int $wordCount)
     {
         return $wordCount / $this->minWordPerThread >= $this->maxThreads
             ? $this->maxThreads : (int)$wordCount / $this->minWordPerThread;
@@ -407,7 +405,7 @@ class HunSpell
      * @return string
      * @author Synida Pry
      */
-    protected function findCommand($text)
+    protected function findCommand(string $text)
     {
         $encode = strncasecmp(PHP_OS, 'WIN', 3) === 0 ? '' : "LANG=\"{$this->encoding}\"; ";
 
@@ -433,7 +431,7 @@ class HunSpell
      * @throws InvalidThreadNumberException
      * @author Synida Pry
      */
-    public function setMaxThreads($maxThreads)
+    public function setMaxThreads(int $maxThreads)
     {
         // Validates the thread number.
         $this->inputValidator->validateThreadNumber($maxThreads);

--- a/src/HunSpellPhpWrapper/Installer.php
+++ b/src/HunSpellPhpWrapper/Installer.php
@@ -89,7 +89,7 @@ class Installer
      * @throws InvalidThreadNumberException
      * @author Synida Pry
      */
-    public static function configureWordPerThreadRatio($threads = 2)
+    public static function configureWordPerThreadRatio(int $threads = 2)
     {
         if (!extension_loaded('parallel')) {
             return 1;

--- a/src/HunSpellPhpWrapper/validation/InputValidator.php
+++ b/src/HunSpellPhpWrapper/validation/InputValidator.php
@@ -18,7 +18,7 @@ class InputValidator
     /**
      * Validates the thread number.
      *
-     * @param int $threadNumber
+     * @param mixed $threadNumber
      * @return void
      * @throws InvalidThreadNumberException
      * @author Synida Pry
@@ -28,7 +28,7 @@ class InputValidator
         // Validates the thread number parameter.
         if (!$this->isValidThreadNumber($threadNumber)) {
             throw new InvalidThreadNumberException(
-                sprintf('Thread number must be a positive integer')
+                'Thread number must be a positive integer'
             );
         }
     }
@@ -36,7 +36,7 @@ class InputValidator
     /**
      * Validates the response type
      *
-     * @param string $responseType
+     * @param mixed $responseType
      * @return void
      * @throws InvalidResponseTypeException
      * @author Synida Pry
@@ -57,19 +57,19 @@ class InputValidator
     /**
      * Validates the thread number parameter.
      *
-     * @param int $threadNumber
+     * @param mixed $threadNumber
      * @return bool
      * @author Synida Pry
      */
     protected function isValidThreadNumber($threadNumber)
     {
-        return is_numeric($threadNumber) && is_int($threadNumber) && $threadNumber > 0;
+        return is_int($threadNumber) && $threadNumber > 0;
     }
 
     /**
      * Checking if the response type is valid or not.
      *
-     * @param string $responseType
+     * @param mixed $responseType
      * @return bool
      * @author Synida Pry
      */

--- a/tests/DictionaryTest.php
+++ b/tests/DictionaryTest.php
@@ -66,7 +66,7 @@ class DictionaryTest extends TestCase
         $fileContent = file_get_contents($dictionaryPath);
         $fileWords = explode("\n", $fileContent);
 
-        $fileWords = preg_replace('/(\r\n)|\r|\n/', '', $fileWords);
+        $fileWords = preg_replace('/(\r\n)|\r|\n/', '', (string)$fileWords);
 
         $this->assertTrue(isset($fileWords[0]));
         $this->assertTrue(is_numeric($fileWords[0]));
@@ -234,7 +234,7 @@ class DictionaryTest extends TestCase
     }
 
     /**
-     * Trying to delete non existing word from the dictionary
+     * Trying to delete non-existing word from the dictionary
      *
      * @return void
      * @author Synida Pry
@@ -259,7 +259,7 @@ class DictionaryTest extends TestCase
     }
 
     /**
-     * Trying to modify non existing word
+     * Trying to modify non-existing word
      *
      * @return void
      * @author Synida Pry
@@ -285,7 +285,7 @@ class DictionaryTest extends TestCase
     }
 
     /**
-     * Trying to edit a word to an another existing word
+     * Trying to edit a word to an existing word
      *
      * @return void
      * @author Synida Pry


### PR DESCRIPTION
+ stronger types
+ FIX: preg_replace(): Passing null to parameter ($subject) of type array|string is deprecated in the case when null returns in PHP 8.2 and 8.1 for any of the find commands